### PR TITLE
Fix children prop type error

### DIFF
--- a/packages/react-split-grid/src/index.js
+++ b/packages/react-split-grid/src/index.js
@@ -209,7 +209,7 @@ class ReactSplitGrid extends React.Component {
 ReactSplitGrid.propTypes = {
     component: PropTypes.element,
     render: PropTypes.func,
-    children: PropTypes.element,
+    children: PropTypes.arrayOf(PropTypes.element),
     gridTemplateColumns: PropTypes.string,
     gridTemplateRows: PropTypes.string,
     columnMinSizes: PropTypes.objectOf(PropTypes.number),


### PR DESCRIPTION
Address this:
```
Warning: Failed prop type: Invalid prop `children` of type `function` supplied to `ReactSplitGrid`, expected a single ReactElement.
    at ReactSplitGrid (webpack-internal:///../../node_modules/react-split-grid/dist/react-split-grid.es.js:18:20)
    at DetailGridWithSplit (webpack-internal:///./src/components/Layouts/GridLayoutWithSplit/DetailGrid.tsx:138:3)
```